### PR TITLE
Fixed Context Lost error by disposing renderer on component unmount

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@johnn-e/react-mesh-gradient",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@johnn-e/react-mesh-gradient",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@react-three/drei": "^9.64.0",
         "@react-three/fiber": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@johnn-e/react-mesh-gradient",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "homepage": "https://github.com/JohnnyLeek1/React-Mesh-Gradient",
   "repository": {

--- a/src/lib/components/MeshGradient.tsx
+++ b/src/lib/components/MeshGradient.tsx
@@ -114,6 +114,8 @@ function MeshGradient({
     renderer.useLegacyLights = true;
     renderer.outputEncoding = THREE.sRGBEncoding;
 
+    return () => renderer.dispose();
+
   });
 
   // Every frame, update the time with the current speed, multiplied by the delta time (to ensure a consistent rate across all devices)


### PR DESCRIPTION
Closes #2 

Finally back to maintaining this. Disposes of renderer when the component is unmount to prevent the error stating `THREE.WebGLRenderer: Context Lost.`